### PR TITLE
Same Logo (as previous)

### DIFF
--- a/forms/form_v2.html
+++ b/forms/form_v2.html
@@ -49,12 +49,12 @@
                     <label for="helmetModel${i}">Helmet Model:</label><br>
                     <select id="helmetModel${i}" name="helmetModel${i}" required>
                         <option value="Standard Brim">Standard Brim</option>
-                        <option value="Full Brim">Full Brim</option>
+                        <option value="Full Brim" selected="selected">Full Brim</option>
                     </select><br><br>
 
                     <label for="helmetClass${i}">Helmet Class:</label><br>
                     <select id="helmetClass${i}" name="helmetClass${i}" required>
-                        <option value="Vented Class C">Vented Class C</option>
+                        <option value="Vented Class C" selected="selected">Vented Class C</option>
                         <option value="Non-Vented Class E">Non-Vented Class E</option>
                     </select><br><br>
 
@@ -74,7 +74,7 @@
                         <option value="Red">Red</option>
                         <option value="SafetyYellow">SafetyYellow</option>
                         <option value="Teal">Teal</option>
-                        <option value="White">White</option>
+                        <option value="White" selected="selected">White</option>
                         <option value="WhiteCarbon">WhiteCarbon</option>
                         <option value="Black">Black</option>
                         <option value="RoyalBlue">RoyalBlue</option>
@@ -110,7 +110,7 @@
                     <label for="logoType${mockupNumber}_${view}">Logo Type:</label>
                     <select name="logoType${mockupNumber}_${view}" onchange="updateLogoFields(this, ${mockupNumber}, '${view}')"}>
                         <option value="New Logo" selected>New Logo</option>
-                        <option value="Same Logo" ${mockupNumber === 1 ? 'disabled' : ''}>Same Logo</option>
+                        <option value="Same Logo (as previous)" ${mockupNumber === 1 ? 'disabled' : ''}>Same Logo (as previous)</option>
                         <option value="American Flag">American Flag</option>
                         <option value="American Flag (transparent)">American Flag (transparent)</option>
                     </select><br>
@@ -138,8 +138,8 @@
             const logoFields = document.getElementById(`logoFields${mockupNumber}_${view}`);
             const pmsColorsContainer = document.getElementById(`pmsColorsContainer${mockupNumber}_${view}`);
             switch (select.value) {
-                case "Same Logo":
-                    logoFields.innerHTML = ""; // Clear fields for "Same Logo"
+                case "Same Logo (as previous)":
+                    logoFields.innerHTML = ""; // Clear fields for "Same Logo (as previous)"
                     pmsColorsContainer.innerHTML = ""; // Clear PMS fields
                     break;
                 case "American Flag":

--- a/function/test_form_read.js
+++ b/function/test_form_read.js
@@ -145,12 +145,12 @@ async function techpackGenerator(fields, files, console) {
                 case "New Logo":
                     break;
 
-                case "Same Logo":
-                    files[key_logo_file] = files[`logo1_${view}`];
-                    fields[key_width] = fields[`logoWidth1_${view}`];
-                    fields[key_shift] = fields[`logoShift1_${view}`];
-                    fields[key_pms] = fields[`pmsCode1_${view}[]`]
-                    fields[key_hex] = fields[`hexCode1_${view}[]`]
+                case "Same Logo (as previous)":
+                    files[key_logo_file] = files[`logo${i}_${view}`];
+                    fields[key_width] = fields[`logoWidth${i}_${view}`];
+                    fields[key_shift] = fields[`logoShift${i}_${view}`];
+                    fields[key_pms] = fields[`pmsCode${i}_${view}[]`]
+                    fields[key_hex] = fields[`hexCode${i}_${view}[]`]
                     break;
 
                 case "American Flag":


### PR DESCRIPTION
Added functionality when selecting logo type "Same Logo" so that the previous logo is used, not the first logo. This allow for multiple different logos to be reused throughout the form. Eg first four mockups could use one logo and the second 4 could use another by adding a new logo for the first of each four, then selecting "Same Logo (as previous)" for the remaining three.